### PR TITLE
feat:default phone number to have  +254 isocode when creating superuser

### DIFF
--- a/CMS/settings.py
+++ b/CMS/settings.py
@@ -117,6 +117,7 @@ USE_I18N = True
 
 USE_TZ = True
 
+PHONENUMBER_DEFAULT_REGION = 'KE'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -22,6 +22,12 @@ class User(AbstractUser):
     def __str__(self) -> str:
         return f'{self.first_name} {self.last_name}'
 
+    def __init__(self, *args, region=None, **kwargs):
+        """
+        The function takes in a region and then sets the region to the region that was passed in when the user is created
+        """
+        super().__init__(*args, **kwargs)
+        self.region = region
 
 class Account(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)#Referencing the customized user


### PR DESCRIPTION
# Description

The default iso code is hardcoded in the settings.py file and I used a small function in the models to specify the region code.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

