### PR TITLE
customized simple JWT token claims to enable token decoding on the frontend

### DIFF
--- a/CMS/settings.py
+++ b/CMS/settings.py
@@ -44,6 +44,8 @@ INSTALLED_APPS = [
     'accounts',
     'blog',
     'phonenumber_field',
+    # for blacklisting used refresh token
+    'rest_framework_simplejwt.token_blacklist',
 ]
 
 MIDDLEWARE = [
@@ -143,6 +145,33 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'AUTH_HEADERS': 'JWT',
-    'ACCESS_TOKEN_LIFETIME': timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=90),
+    # enables users to remain logged in after given days expire as long as the user stays in the system.
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True,
+    'UPDATE_LAST_LOGIN': False,
+
+    'ALGORITHM': 'HS256',
+    'VERIFYING_KEY': None,
+    'AUDIENCE': None,
+    'ISSUER': None,
+    'JWK_URL': None,
+    'LEEWAY': 0,
+
+    'AUTH_HEADER_TYPES': ('Bearer',),
+    'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+    'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
+
+    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'TOKEN_TYPE_CLAIM': 'token_type',
+    'TOKEN_USER_CLASS': 'rest_framework_simplejwt.models.TokenUser',
+
+    'JTI_CLAIM': 'jti',
+
+    'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
+    'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
+    'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
 }

--- a/CMS/urls.py
+++ b/CMS/urls.py
@@ -15,21 +15,26 @@ Including another URLconf
 """
 from django.contrib import admin
 
+from rest_framework_simplejwt.views import (
+    TokenRefreshView,
+)
+
+from accounts.views import MyTokenObtainPairView
+
 from django.urls import path, include
-from rest_framework_simplejwt import views as jwt_views
 from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 
-    path('api/token/', jwt_views.TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', jwt_views.TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/token/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
 
     path("", include("accounts.urls"))
 ] + static(settings.MEDIA_URL,
-document_root=settings.MEDIA_ROOT)
+           document_root=settings.MEDIA_ROOT)
 
 admin.site.site_header = "SpaceYaTech CMS Admin"
 admin.site.site_title = "SpaceYaTech Admin Portal"

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -3,29 +3,58 @@ from rest_framework.viewsets import ModelViewSet, GenericViewSet
 from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.views import TokenObtainPairView
+
 from accounts.models import *
 from .serializers import *
 from .models import *
 
+""" Api view for customizing token claims, this is useful when it comes to logging in user in the frontend """
+
+
+class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+
+        # Add custom claims
+        token["email"] = user.email,
+        token["username"] = user.username
+        # ...
+
+        return token
+
+
+class MyTokenObtainPairView(TokenObtainPairView):
+    serializer_class = MyTokenObtainPairSerializer
+
 
 """Api View for listing all users and retrieving specific users using their id's"""
+
+
 class UserViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     serializer_class = UserSerializer
     permission_classes = [IsAdminUser]
 
     def get_queryset(self):
         if self.request.method == 'GET':
-            return User.objects.annotate(number_of_accounts=Count('account'))#Adds a new column that counts the number of accounts.
+            # Adds a new column that counts the number of accounts.
+            return User.objects.annotate(number_of_accounts=Count('account'))
         return User.objects.all()
 
 
 """Api view to be used when a user first registers to the system"""
+
+
 class RegisterAccountViewSet(CreateModelMixin, GenericViewSet):
     queryset = Account.objects.all()
     serializer_class = UserAccountRegistrationSerializer
 
 
 """Api view for a user to add another new account"""
+
+
 class AddUserAccountViewSet(ModelViewSet):
     serializer_class = AddAccountSerializer
     permission_classes = [IsAuthenticated]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.5.2
 Django==4.1.3
 djangorestframework==3.14.0
+djangorestframework-simplejwt==5.2.2
 pytz==2022.6
 sqlparse==0.4.3
 tzdata==2022.6
@@ -8,6 +9,6 @@ django-phonenumber-field==7.0.0 # enables localization of phone number based on 
 phonenumbers==8.13.0
 Pillow==9.3.0
 drf-nested-routers
-djangorestframework_simplejwt
 model_bakery
-pytest-django
+pytest-django==4.5.2
+black==22.12.0 # used for formatting code


### PR DESCRIPTION
# Description
This feature is the extension of the authentication feature which had been introduced earlier. From earlier implementation, what happens after the refresh token expires? You request another token, but this time it only returns the refresh token only, So I wanted to have both refresh and token return that's why I included `ROTATE_REFRESH_TOKENS:True` and when you request another token I want to ensure that the refresh token used has to be blacklisted, you will not reuse the refresh token again, this is for security purposes, so we set `BLACKLIST_AFTER_ROTATION: True,` 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

